### PR TITLE
PULL REQUEST: File paths update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ target/
 .classpath
 .settings
 .settings/*
+results

--- a/README.mdown
+++ b/README.mdown
@@ -18,7 +18,7 @@ Database
 --------
 This distribution of FixCache operates on a MySQL database constructed by [our fork of CVSanalY2](http://github.com/SoftwareIntrospectionLab/cvsanaly) constructed with the following parameters:
 
-    ./cvsanaly2 -g -f config.sqlite --extensions=FileTypes,BugFixMessage,Content,FileCount,Patches,Hunks,HunkBlame --hard-order [repository path]
+    ./cvsanaly2 --db-user=[user] --db-password=[password] --extensions=FileTypes,BugFixMessage,Content,FileCount,Patches,Hunks,HunkBlame --hard-order [repository path]
 
 To allow FixCache to run unit tests without instansiating a database, the unit tests on an in-memory SQLite database. As Java has no standard SQLite library (for shame!), a dependency is downloaded automatically by Maven.
 

--- a/RUN
+++ b/RUN
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-mvn build exec:java -Dexec.args="--help"
+mvn compile exec:java -Dexec.args="--help"

--- a/fixcache.xml
+++ b/fixcache.xml
@@ -35,6 +35,15 @@
   <actions id="18" type="M" file_id="5" commit_id="9" branch_id="1"/>
   <actions id="19" type="V" file_id="8" commit_id="10" branch_id="1"/>
   <actions id="20" type="M" file_id="5" commit_id="10" branch_id="1"/>
+  <file_paths id="1" commit_id="1" file_id="1" file_path="/foo/bar/a.java"/>
+  <file_paths id="2" commit_id="1" file_id="2" file_path="/foo/bar/b"/>
+  <file_paths id="3" commit_id="1" file_id="3" file_path="/foo/bar/c.java"/>
+  <file_paths id="4" commit_id="1" file_id="4" file_path="/foo/bar/d.java"/>
+  <file_paths id="5" commit_id="3" file_id="5" file_path="/foo/bar/e.java"/>
+  <file_paths id="6" commit_id="6" file_id="6" file_path="/foo/bar/f.java"/>  
+  <file_paths id="7" commit_id="6" file_id="7" file_path="/foo/bar/g.java"/>
+  <file_paths id="8" commit_id="8" file_id="8" file_path="/foo/bar/h.java"/>
+  <file_paths id="9" commit_id="10" file_id="8" file_path="/bar/foo/h.java"/>
   <file_types id="1" file_id="1" type="code"/>
   <file_types id="2" file_id="2" type="unknown"/>
   <file_types id="3" file_id="3" type="code"/>

--- a/src/main/java/edu/ucsc/sil/fixcache/cache/Cache.java
+++ b/src/main/java/edu/ucsc/sil/fixcache/cache/Cache.java
@@ -262,9 +262,10 @@ public class Cache implements Iterable<CacheItem>{
         StringBuilder s = new StringBuilder();
         s.append("[");
         for (CacheItem ci: this){
-            if (ci.isInCache())
-                s.append(ci.getFileName());
+            if (ci.isInCache()) {
+                s.append(ci.getFileId());
             	s.append(",");
+            }
         }
         s.append("]");
         return s.toString();

--- a/src/main/java/edu/ucsc/sil/fixcache/cache/Cache.java
+++ b/src/main/java/edu/ucsc/sil/fixcache/cache/Cache.java
@@ -71,8 +71,8 @@ public class Cache implements Iterable<CacheItem>{
         return inCacheList.iterator();
     }
     
-    public Collection<CacheItem> allCacheValues() {
-        return cacheTable.values();
+    public Iterator<CacheItem> allCacheValues() {
+        return cacheTable.values().iterator();
     }
 
     /**

--- a/src/main/java/edu/ucsc/sil/fixcache/cache/Cache.java
+++ b/src/main/java/edu/ucsc/sil/fixcache/cache/Cache.java
@@ -10,7 +10,7 @@ import edu.ucsc.sil.fixcache.cache.CacheItem.CacheReason;
 
 import edu.ucsc.sil.fixcache.util.Dates;
 
-public class Cache implements Iterable<CacheItem>{
+public class Cache{
 
     /**
      *  Invariant: cacheTable.size() <= size;
@@ -58,19 +58,6 @@ public class Cache implements Iterable<CacheItem>{
     /**
      * Methods
      */
-    
-    // used in file distribution output
-    @Override
-    public Iterator<CacheItem> iterator() {
-        List<CacheItem> inCacheList = new ArrayList<CacheItem>();
-        
-        for (CacheItem ci : cacheTable.values()) {
-            inCacheList.add(ci);
-        }
-        
-        return inCacheList.iterator();
-    }
-    
     public Iterator<CacheItem> allCacheValues() {
         return cacheTable.values().iterator();
     }
@@ -274,7 +261,9 @@ public class Cache implements Iterable<CacheItem>{
     public String toString(){
         StringBuilder s = new StringBuilder();
         s.append("[");
-        for (CacheItem ci: this){
+        Iterator<CacheItem> allCacheValues = allCacheValues();
+        while (allCacheValues.hasNext()) {
+            CacheItem ci = allCacheValues.next();
             if (ci.isInCache()) {
                 s.append(ci.getFileId());
             	s.append(",");

--- a/src/main/java/edu/ucsc/sil/fixcache/cache/Cache.java
+++ b/src/main/java/edu/ucsc/sil/fixcache/cache/Cache.java
@@ -233,7 +233,7 @@ public class Cache implements Iterable<CacheItem>{
      * Returns either the CacheItem associated with entityId, if in the cache
      * or null if it is not in the cache.
      */
-    public CacheItem getCacheItem(String entityId) {
+    public CacheItem getCacheItem(int entityId) {
         CacheItem ci = cacheTable.get(entityId);
         if (ci == null)
             return null;
@@ -252,8 +252,8 @@ public class Cache implements Iterable<CacheItem>{
         return ci.getNumber();
     }
 
-    public int getLoadCount(String fileName){
-        CacheItem ci = cacheTable.get(fileName);
+    public int getLoadCount(int fileId){
+        CacheItem ci = cacheTable.get(fileId);
         return ci.getLoadCount();
     }
     

--- a/src/main/java/edu/ucsc/sil/fixcache/cache/Cache.java
+++ b/src/main/java/edu/ucsc/sil/fixcache/cache/Cache.java
@@ -20,7 +20,7 @@ public class Cache implements Iterable<CacheItem>{
     private int size = 0; // current size of cache
 
     // keeps every cacheitem that was ever in the cache
-    private Hashtable<String, CacheItem> cacheTable = new Hashtable<String, CacheItem>();
+    private Hashtable<Integer, CacheItem> cacheTable = new Hashtable<Integer, CacheItem>();
 
     final private CacheReplacement policy;
     final String startDate; 
@@ -78,11 +78,11 @@ public class Cache implements Iterable<CacheItem>{
      */
     // XXX: load a chunk at a time??
     public void load(CacheItem cacheItem, String cdate) {
-        String fileName = cacheItem.getFileName();
+        int fileId = cacheItem.getFileId();
         if (isFull())
             bumpOutItem(cdate);
         if (!cacheTable.contains(cacheItem))
-            cacheTable.put(fileName, cacheItem);
+            cacheTable.put(fileId, cacheItem);
         size++;
     }
 
@@ -91,7 +91,7 @@ public class Cache implements Iterable<CacheItem>{
      * The only method that decreases size.
      * @param fileid 
      */
-    public void remove(String fileid, String cdate) {
+    public void remove(int fileid, String cdate) {
         cacheTable.get(fileid).removeFromCache(cdate);
         size--;
     }
@@ -105,16 +105,16 @@ public class Cache implements Iterable<CacheItem>{
      * @param cdate -- commit date
      * @param reason -- reason for adding to the cache
      */
-    public void add(String fileName, int cid, String cdate, CacheReason reason) {
-        if (cacheTable.containsKey(fileName)){ // either in cache or was bumped out
-            CacheItem ci = cacheTable.get(fileName);
+    public void add(int fileId, int cid, String cdate, CacheReason reason) {
+        if (cacheTable.containsKey(fileId)){ // either in cache or was bumped out
+            CacheItem ci = cacheTable.get(fileId);
             if (!ci.isInCache()){
                 load(ci, cdate);
                 addCount++;
             }
             ci.update(cid, cdate, startDate, reason); // updates inCache status
         } else { // need to create a new CacheItem
-            load(new CacheItem(fileName, cid, cdate, reason, this), cdate);
+            load(new CacheItem(fileId, cid, cdate, reason, this), cdate);
             addCount++;
             numNewItems++;
         }
@@ -128,11 +128,11 @@ public class Cache implements Iterable<CacheItem>{
      */
     // TODO: keep cache always sorted using cache replacement policy
     public void bumpOutItem(String cdate) {
-        String entityId = getMinimum();
+        int entityId = getMinimum();
         remove(entityId, cdate);
     }
 
-    public String getMinimum() {
+    public int getMinimum() {
         CacheItem min = null;
 
         for (CacheItem c : cacheTable.values()) {
@@ -143,7 +143,7 @@ public class Cache implements Iterable<CacheItem>{
             else
                 min = policy.minimum(min, c);
         }
-        return min.getFileName();
+        return min.getFileId();
     }
 
     /**
@@ -193,7 +193,7 @@ public class Cache implements Iterable<CacheItem>{
      * @param eid -- entity id
      * @return whether that entity is in the cache
      */
-    public boolean contains(String eid){
+    public boolean contains(int eid){
         final CacheItem ci = cacheTable.get(eid);
         if (ci == null)
             return false;
@@ -217,8 +217,8 @@ public class Cache implements Iterable<CacheItem>{
     }
     
 
-    int getLoc(String fileid){
-        CacheItem ci = cacheTable.get(fileid);
+    int getLoc(int fileId){
+        CacheItem ci = cacheTable.get(fileId);
         if (ci == null)
             return -1;
         return ci.getLOC();
@@ -243,7 +243,7 @@ public class Cache implements Iterable<CacheItem>{
     }
     
     
-    public boolean neverInCache(String entityId){
+    public boolean neverInCache(int entityId){
         return (cacheTable.get(entityId) == null);
     }
 

--- a/src/main/java/edu/ucsc/sil/fixcache/cache/Cache.java
+++ b/src/main/java/edu/ucsc/sil/fixcache/cache/Cache.java
@@ -1,7 +1,10 @@
 package edu.ucsc.sil.fixcache.cache;
 
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Hashtable;
 import java.util.Iterator;
+import java.util.List;
 
 import edu.ucsc.sil.fixcache.cache.CacheItem.CacheReason;
 
@@ -59,7 +62,17 @@ public class Cache implements Iterable<CacheItem>{
     // used in file distribution output
     @Override
     public Iterator<CacheItem> iterator() {
-        return cacheTable.values().iterator();
+        List<CacheItem> inCacheList = new ArrayList<CacheItem>();
+        
+        for (CacheItem ci : cacheTable.values()) {
+            inCacheList.add(ci);
+        }
+        
+        return inCacheList.iterator();
+    }
+    
+    public Collection<CacheItem> allCacheValues() {
+        return cacheTable.values();
     }
 
     /**

--- a/src/main/java/edu/ucsc/sil/fixcache/cache/CacheItem.java
+++ b/src/main/java/edu/ucsc/sil/fixcache/cache/CacheItem.java
@@ -85,6 +85,7 @@ public class CacheItem {
         parent = p;
         update(cid, cdate, p.getStartDate(), r);
         assert (r != CacheReason.BugEntity || missCount != 0);
+        assert (fileId > 0);
         assert (parent.neverInCache(fileId));
         assert (checkFileType(fileId));
         assert (checkRepo(p.repID, cid));

--- a/src/main/java/edu/ucsc/sil/fixcache/cache/CacheItem.java
+++ b/src/main/java/edu/ucsc/sil/fixcache/cache/CacheItem.java
@@ -58,6 +58,7 @@ public class CacheItem {
     }
 
     private final int fileId; // id of file
+    private String filePath = null;
     private int loadDate; // changed on cache hit
     private int LOC; // changed on cache hit; max LOC
     private int number; // represents either the number of bugs, changes, or
@@ -290,10 +291,16 @@ public class CacheItem {
     }
 
     /**
-     * @return Returns the entityId.
+     * @return Returns the file path. The first time this runs, its expensive.
      */
-    public String getFileName() {
-        String filePath = Integer.toString(getFileId());
+    public String getFilePath() {
+        if (filePath != null) {
+          return filePath;
+        }
+        
+        // Just in case we don't have a file path, return something reasonably
+        // useful
+        filePath = Integer.toString(getFileId());
         
         final String findFilePath = "select fp.file_path " + 
             "from file_paths fp " + 

--- a/src/main/java/edu/ucsc/sil/fixcache/cache/CacheItem.java
+++ b/src/main/java/edu/ucsc/sil/fixcache/cache/CacheItem.java
@@ -18,20 +18,19 @@ public class CacheItem {
 
     static Connection conn = DatabaseManager.getConnection();
     static final String findNumberOfAuthors = "select count(distinct(scmlog.author_id)) "
-            + "from scmlog, actions, files "
-            + "where scmlog.id=actions.commit_id and actions.file_id=files.id "
-            + "and date between ? and ? and file_name = ? and scmlog.repository_id=?";
+            + "from scmlog, actions "
+            + "where scmlog.id=actions.commit_id and actions.file_id=? "
+            + "and date between ? and ? and scmlog.repository_id=?";
     static final String findNumberOfChanges = "select count(actions.file_id) "
-            + "from scmlog, actions, files where scmlog.id=actions.commit_id "
-            + "and actions.file_id=files.id and date between ? and ? and file_name = ? "
+            + "from scmlog, actions where scmlog.id=actions.commit_id "
+            + "and actions.file_id=? and date between ? and ?"
             + "and scmlog.repository_id=?";
     static final String findNumberOfBugs = "select count(actions.file_id) "
-            + "from scmlog, actions, files where scmlog.id = actions.commit_id "
-            + "and actions.file_id=files.id and file_name=? and date between ? and ? "
+            + "from scmlog, actions where scmlog.id = actions.commit_id "
+            + "and actions.file_id=? and date between ? and ? "
             + "and scmlog.repository_id=? and is_bug_fix=1";
-    static final String findLoc = "select loc from content, files "
-            + "where content.file_id=files.id and"
-            + " file_name=? and commit_id =?";
+    static final String findLoc = "select loc from content "
+            + "where file_id = ? and commit_id = ?";
     private static PreparedStatement findNumberOfAuthorsQuery;
     private static PreparedStatement findNumberOfChangesQuery;
     private static PreparedStatement findNumberOfBugsQuery;
@@ -45,9 +44,8 @@ public class CacheItem {
             + "repository_id = ? and id = ?";
     private static PreparedStatement checkRepoQuery;
 
-    private static final String checkFileType = "select file_id from "
-            + "file_types, files where file_name = ? and "
-            + "file_id = files.id and type='code'";
+    private static final String checkFileType = "select ft.file_id from "
+            + "file_types ft where ft.file_id = ? and ft.type='code' ";
     private static PreparedStatement checkFileTypeQuery;
 
     /**
@@ -59,7 +57,7 @@ public class CacheItem {
         Preload, CoChange, NewEntity, ModifiedEntity, BugEntity
     }
 
-    private final String fileName; // id of file
+    private final int fileId; // id of file
     private int loadDate; // changed on cache hit
     private int LOC; // changed on cache hit; max LOC
     private int number; // represents either the number of bugs, changes, or
@@ -81,14 +79,14 @@ public class CacheItem {
      * Methods
      */
 
-    public CacheItem(String fName, int cid, String cdate, CacheReason r, Cache p) {
-        fileName = fName;
+    public CacheItem(int fId, int cid, String cdate, CacheReason r, Cache p) {
+        fileId = fId;
         reason = r;
         parent = p;
         update(cid, cdate, p.getStartDate(), r);
         assert (r != CacheReason.BugEntity || missCount != 0);
-        assert (parent.neverInCache(fileName));
-        assert (checkFileType(fileName));
+        assert (parent.neverInCache(fileId));
+        assert (checkFileType(fileId));
         assert (checkRepo(p.repID, cid));
     }
 
@@ -116,8 +114,8 @@ public class CacheItem {
                 hitCount++;
         }
         loadDate = parent.getTime(cid); 
-        LOC = Math.max(LOC, findLoc(fileName, cid)); // max LOC
-        int newnumber = findNumber(fileName, parent.repID, cdate, sdate,
+        LOC = Math.max(LOC, findLoc(fileId, cid)); // max LOC
+        int newnumber = findNumber(fileId, parent.repID, cdate, sdate,
                 parent.getPolicy());
         number = newnumber < 0? number: newnumber;
     }
@@ -150,18 +148,18 @@ public class CacheItem {
      * @return the number of bug fixes for file eid in repository pid between
      *         cdate and start
      */
-    private static int findNumber(String fileName, int pid, String cdate,
+    private static int findNumber(int fileId, int pid, String cdate,
             String sdate, Policy pol) {
         int ret = 0;
         switch (pol) {
         case BUGS:
-            ret = findNumberOfBugs(fileName, pid, cdate, sdate);
+            ret = findNumberOfBugs(fileId, pid, cdate, sdate);
             break;
         case CHANGES:
-            ret = findNumberOfChanges(fileName, pid, cdate, sdate);
+            ret = findNumberOfChanges(fileId, pid, cdate, sdate);
             break;
         case AUTHORS:
-            ret = findNumberOfAuthors(fileName, pid, cdate, sdate);
+            ret = findNumberOfAuthors(fileId, pid, cdate, sdate);
             break;
         case LRU: // do nothing
         }
@@ -183,16 +181,16 @@ public class CacheItem {
      *         DatabaseTest dbTest = new DatabaseTest(); dbTest. between cdate
      *         and start
      */
-    private static int findNumberOfAuthors(String fileName, int pid,
+    private static int findNumberOfAuthors(int fileId, int pid,
             String cdate, String start) {
         int ret = 0;
         try {
             // if (findNumberOfAuthorsQuery == null)
             findNumberOfAuthorsQuery = conn
                     .prepareStatement(findNumberOfAuthors);
-            findNumberOfAuthorsQuery.setString(1, start);
-            findNumberOfAuthorsQuery.setString(2, cdate);
-            findNumberOfAuthorsQuery.setString(3, fileName); 
+            findNumberOfAuthorsQuery.setInt(1, fileId); 
+            findNumberOfAuthorsQuery.setString(2, start);
+            findNumberOfAuthorsQuery.setString(3, cdate);
             findNumberOfAuthorsQuery.setInt(4, pid);
             ret = Database.getIntResult(findNumberOfAuthorsQuery);
             findNumberOfAuthorsQuery.close();
@@ -215,16 +213,16 @@ public class CacheItem {
      * @return the number of commits for file eid in repository pid between
      *         cdate and start
      */
-    private static int findNumberOfChanges(String fileName, int pid,
+    private static int findNumberOfChanges(int fileId, int pid,
             String cdate, String start) {
         int ret = 0;
         try {
             // if (findNumberOfChangesQuery == null)
             findNumberOfChangesQuery = conn
                     .prepareStatement(findNumberOfChanges);
-            findNumberOfChangesQuery.setString(1, start);
-            findNumberOfChangesQuery.setString(2, cdate);
-            findNumberOfChangesQuery.setString(3, fileName); 
+            findNumberOfChangesQuery.setInt(1, fileId);
+            findNumberOfChangesQuery.setString(2, start);
+            findNumberOfChangesQuery.setString(3, cdate);
             findNumberOfChangesQuery.setInt(4, pid);
             ret = Database.getIntResult(findNumberOfChangesQuery);
             findNumberOfChangesQuery.close();
@@ -247,14 +245,14 @@ public class CacheItem {
      * @return the number of bug fixes for file eid in repository pid between
      *         cdate and start
      */
-    private static int findNumberOfBugs(String fileName, int pid, String cdate,
+    private static int findNumberOfBugs(int fileId, int pid, String cdate,
             String start) {
         int ret = 0;
         try {
             // if (findNumberOfBugsQuery == null)
             findNumberOfBugsQuery = conn.prepareStatement(findNumberOfBugs);
 
-            findNumberOfBugsQuery.setString(1, fileName);
+            findNumberOfBugsQuery.setInt(1, fileId);
             findNumberOfBugsQuery.setString(2, start);
             findNumberOfBugsQuery.setString(3, cdate);
             findNumberOfBugsQuery.setInt(4, pid);
@@ -275,13 +273,12 @@ public class CacheItem {
      *            -- commit id
      * @return the lines of code for eid at cid
      */
-    protected static int findLoc(String fileName, int cid) {
+    protected static int findLoc(int fileId, int cid) {
         int ret = 0;
         try {
             // if (findLocQuery == null)
             findLocQuery = conn.prepareStatement(findLoc);
-            findLocQuery.setString(1, fileName); // XXX fix query to use
-                                                 // file_name
+            findLocQuery.setInt(1, fileId);
             findLocQuery.setInt(2, cid);
             ret = Database.getIntResult(findLocQuery);
             findLocQuery.close();
@@ -295,7 +292,11 @@ public class CacheItem {
      * @return Returns the entityId.
      */
     public String getFileName() {
-        return fileName;
+        return Integer.toString(fileId);
+    }
+    
+    public int getFileId() {
+      return fileId;
     }
 
     /**
@@ -421,11 +422,11 @@ public class CacheItem {
      *            -- filename
      * @return true if it is a code file, false otherwise
      */
-    private boolean checkFileType(String fname) {
+    private boolean checkFileType(int fileId) {
         boolean isCode = false;
         try {
             checkFileTypeQuery = conn.prepareStatement(checkFileType);
-            checkFileTypeQuery.setString(1, fname);
+            checkFileTypeQuery.setInt(1, fileId);
             isCode = checkFileTypeQuery.executeQuery().next();
             checkFileTypeQuery.close();
         } catch (SQLException e1) {

--- a/src/main/java/edu/ucsc/sil/fixcache/cache/CacheItem.java
+++ b/src/main/java/edu/ucsc/sil/fixcache/cache/CacheItem.java
@@ -294,27 +294,25 @@ public class CacheItem {
      * @return Returns the file path. The first time this runs, its expensive.
      */
     public String getFilePath() {
-        if (filePath != null) {
-          return filePath;
-        }
-        
-        // Just in case we don't have a file path, return something reasonably
-        // useful
-        filePath = Integer.toString(getFileId());
-        
-        final String findFilePath = "select fp.file_path " + 
-            "from file_paths fp " + 
-            "where file_id = ? " + 
-            "order by id desc " + 
-            "limit 1";
-        
-        try {
-            final PreparedStatement findFilePathQuery = 
-                conn.prepareStatement(findFilePath);
-            findFilePathQuery.setInt(1, getFileId());
-            filePath = Database.getStringResult(findFilePathQuery);
-        } catch (SQLException e1) {
-            e1.printStackTrace();
+        if (filePath == null) {   
+            // Just in case we don't have a file path, return something reasonably
+            // useful
+            filePath = Integer.toString(getFileId());
+            
+            final String findFilePath = "select fp.file_path " + 
+                "from file_paths fp " + 
+                "where file_id = ? " + 
+                "order by id desc " + 
+                "limit 1";
+            
+            try {
+                final PreparedStatement findFilePathQuery = 
+                    conn.prepareStatement(findFilePath);
+                findFilePathQuery.setInt(1, getFileId());
+                filePath = Database.getStringResult(findFilePathQuery);
+            } catch (SQLException e1) {
+                e1.printStackTrace();
+            }
         }
         
         return filePath;

--- a/src/main/java/edu/ucsc/sil/fixcache/cache/CacheItem.java
+++ b/src/main/java/edu/ucsc/sil/fixcache/cache/CacheItem.java
@@ -293,7 +293,24 @@ public class CacheItem {
      * @return Returns the entityId.
      */
     public String getFileName() {
-        return Integer.toString(fileId);
+        String filePath = Integer.toString(getFileId());
+        
+        final String findFilePath = "select fp.file_path " + 
+            "from file_paths fp " + 
+            "where file_id = ? " + 
+            "order by id desc " + 
+            "limit 1";
+        
+        try {
+            final PreparedStatement findFilePathQuery = 
+                conn.prepareStatement(findFilePath);
+            findFilePathQuery.setInt(1, getFileId());
+            filePath = Database.getStringResult(findFilePathQuery);
+        } catch (SQLException e1) {
+            e1.printStackTrace();
+        }
+        
+        return filePath;
     }
     
     public int getFileId() {

--- a/src/main/java/edu/ucsc/sil/fixcache/cache/CoChange.java
+++ b/src/main/java/edu/ucsc/sil/fixcache/cache/CoChange.java
@@ -24,13 +24,7 @@ public class CoChange {
         + "where a.file_id=? and a.commit_id=s.id and "
         + "s.date between ? and ? and s.repository_id=?";
     // XXX: don't add deleted files to map
-    static final String findCochangeFileId = "select files.id from files, actions, file_types "
-        + "where commit_id =? and actions.file_id = files.id and "
-        + "files.id=file_types.file_id and file_types.type='code'"; // XXX
-    // and
-    // actions.type
-    // =
-    // 'M'?
+    static final String findCochangeFileId = Simulator.findCommitCodeFiles;
     private static PreparedStatement findCommitIdQuery;
     private static PreparedStatement findCochangeFileNameQuery;
 

--- a/src/main/java/edu/ucsc/sil/fixcache/cache/CoChange.java
+++ b/src/main/java/edu/ucsc/sil/fixcache/cache/CoChange.java
@@ -24,7 +24,7 @@ public class CoChange {
         + "where actions.file_id=? and actions.commit_id=scmlog.id and "
         + "date between ? and ? and scmlog.repository_id=?";
     // XXX: don't add deleted files to map
-    static final String findCochangeFileId = "select file_id from files, actions, file_types "
+    static final String findCochangeFileId = "select files.id from files, actions, file_types "
         + "where files.id=actions.file_id and commit_id =? and "
         + "files.id=file_types.file_id and file_types.type='code'"; // XXX
     // and

--- a/src/main/java/edu/ucsc/sil/fixcache/cache/CoChange.java
+++ b/src/main/java/edu/ucsc/sil/fixcache/cache/CoChange.java
@@ -20,12 +20,12 @@ public class CoChange {
      * database setup
      */
     final static Connection conn = DatabaseManager.getConnection();
-    static final String findCommitId = "select commit_id from actions, scmlog, files "
-        + "where actions.file_id=? and actions.commit_id=scmlog.id and "
-        + "date between ? and ? and scmlog.repository_id=?";
+    static final String findCommitId = "select s.id from actions a, scmlog s "
+        + "where a.file_id=? and a.commit_id=s.id and "
+        + "s.date between ? and ? and s.repository_id=?";
     // XXX: don't add deleted files to map
     static final String findCochangeFileId = "select files.id from files, actions, file_types "
-        + "where files.id=actions.file_id and commit_id =? and "
+        + "where commit_id =? and actions.file_id = files.id and "
         + "files.id=file_types.file_id and file_types.type='code'"; // XXX
     // and
     // actions.type

--- a/src/main/java/edu/ucsc/sil/fixcache/cache/InputManager.java
+++ b/src/main/java/edu/ucsc/sil/fixcache/cache/InputManager.java
@@ -1,5 +1,6 @@
 package edu.ucsc.sil.fixcache.cache;
 
+import java.io.File;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -27,6 +28,7 @@ public class InputManager {
     String start;
     String end;
     boolean saveToFile;
+    String outputDirectory;
     boolean monthly;
 
     /**
@@ -47,6 +49,7 @@ public class InputManager {
         this.start = null;
         this.end = null;
         this.saveToFile = false;
+        this.outputDirectory = null;
         this.monthly = false;
         this.checkParameter();
     }        
@@ -78,6 +81,7 @@ public class InputManager {
         CmdLineParser.Option sd_opt = parser.addStringOption('s', "start");
         CmdLineParser.Option ed_opt = parser.addStringOption('e', "end");
         CmdLineParser.Option save_opt = parser.addBooleanOption('o',"save");
+        CmdLineParser.Option directory_opt = parser.addStringOption('d', "directory");
         CmdLineParser.Option month_opt = parser.addBooleanOption('m',"multiple");
         CmdLineParser.Option tune_opt = parser.addBooleanOption('u', "tune");
         CmdLineParser.Option help_opt = parser.addBooleanOption('h', "help");
@@ -132,6 +136,9 @@ public class InputManager {
         // get the start and end dates
         this.start = (String) parser.getOptionValue(sd_opt, null);
         this.end = (String) parser.getOptionValue(ed_opt, null);
+        
+        // get the output directory
+        this.outputDirectory = (String) parser.getOptionValue(directory_opt, "results");
 
         // check invariants, and replace default parameters
         this.checkParameter();      
@@ -180,6 +187,25 @@ public class InputManager {
         // set defaults for start and end dates
         start = findFirstDate(start, pid);
         end = findLastDate(end, pid);
+        
+        // If we're saving out files, make sure the directory is available
+        File output = new File(outputDirectory);
+        boolean success = false;
+        
+        // Make the directory if it doesn't exist
+        if (saveToFile && (!output.exists())) {
+            try {
+                success = output.mkdir();
+            } catch (SecurityException e) {
+                success = false;
+                e.printStackTrace();
+            }
+            
+            if (!success) {
+                System.err.println("Can't create output directory");
+                System.exit(1);
+            }
+        }
     }
 
     /**

--- a/src/main/java/edu/ucsc/sil/fixcache/cache/OutputManager.java
+++ b/src/main/java/edu/ucsc/sil/fixcache/cache/OutputManager.java
@@ -101,6 +101,7 @@ public class OutputManager {
     public void finish(Simulator sim) {
         if (!save) return;
         outputFileDist(sim, true);
+        outputFinalFileDist(sim);
         
         try {
             hitrateOutput.close();
@@ -201,6 +202,35 @@ public class OutputManager {
             }
 
             // cleanup
+            csv.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+    
+    /**
+     * Output the information that is in the cache at the end
+     * @param sim -- the simulator ran
+     */
+    private void outputFinalFileDist(Simulator sim) {
+        try {
+            CSVWriter csv = new CSVWriter(
+              new FileWriter("results/" + filename + "_final.csv"));
+            
+            String columns[] = {"file_id", "file_name"};
+                            
+            csv.writeNext(columns);
+            
+            for (CacheItem ci : sim.cache) {
+                if (ci.isInCache()) {
+                    String[] record = {Integer.toString(ci.getFileId()),
+                                       ci.getFileName()             
+                    };
+                    
+                    csv.writeNext(record);
+                }
+            }
+            
             csv.close();
         } catch (IOException e) {
             e.printStackTrace();

--- a/src/main/java/edu/ucsc/sil/fixcache/cache/OutputManager.java
+++ b/src/main/java/edu/ucsc/sil/fixcache/cache/OutputManager.java
@@ -217,12 +217,16 @@ public class OutputManager {
                             
             csv.writeNext(columns);
             
-            for (CacheItem ci : sim.cache) {
-                String[] record = {Integer.toString(ci.getFileId()),
-                                   ci.getFilePath()             
-                };
-                
-                csv.writeNext(record);
+            Iterator<CacheItem> allCacheValues = sim.cache.allCacheValues();
+            while (allCacheValues.hasNext()) {
+                CacheItem ci = allCacheValues.next();
+                if (ci.isInCache()) {
+                    String[] record = {Integer.toString(ci.getFileId()),
+                                       ci.getFilePath()             
+                    };
+                    
+                    csv.writeNext(record);
+                }
             }
             
             csv.close();

--- a/src/main/java/edu/ucsc/sil/fixcache/cache/OutputManager.java
+++ b/src/main/java/edu/ucsc/sil/fixcache/cache/OutputManager.java
@@ -3,6 +3,8 @@ package edu.ucsc.sil.fixcache.cache;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.util.Iterator;
+
 import au.com.bytecode.opencsv.CSVWriter;
 
 import edu.ucsc.sil.fixcache.util.Dates;
@@ -179,7 +181,9 @@ public class OutputManager {
             
             // the file already has the correct header line
             // write out each record
-            for (CacheItem ci : sim.cache.allCacheValues()){
+            Iterator<CacheItem> cacheValues = sim.cache.allCacheValues();
+            while (cacheValues.hasNext()){
+                CacheItem ci = cacheValues.next(); 
                 String[] record = {Integer.toString(ci.getFileId()),
                     ci.getFilePath(),
                     Integer.toString(ci.getLOC()), // max LOC

--- a/src/main/java/edu/ucsc/sil/fixcache/cache/OutputManager.java
+++ b/src/main/java/edu/ucsc/sil/fixcache/cache/OutputManager.java
@@ -32,14 +32,6 @@ public class OutputManager {
         outputDate = start;
         filedistPrintMultiple = outputMulti;
         headerPrinted = false;
-        
-        try {
-            boolean success = new File("results").mkdir();
-        } catch (SecurityException e) {
-            String msg = "Can't create results directory due to security.";
-            System.err.println(msg);
-            e.printStackTrace();
-        }
     }
     
     private void writeComment(CSVWriter writer, String comment) {

--- a/src/main/java/edu/ucsc/sil/fixcache/cache/OutputManager.java
+++ b/src/main/java/edu/ucsc/sil/fixcache/cache/OutputManager.java
@@ -173,13 +173,13 @@ public class OutputManager {
                     + sim.prefetchsize + ", cache replacement policy: " + sim.cacheRep);
             
             // column titles. "reason" used to be here, but was commented out.
-            String columns[] = {"file_id", "loc", "num_load", "num_hits",
+            String columns[] = {"file_id", "file_name", "loc", "num_load", "num_hits",
                 "num_misses", "duration"};
             
             csv.writeNext(columns);
             
             // initial row special to store total duration
-            String initialRecord[] = {"0", "0", "0", "0", "0", 
+            String initialRecord[] = {"0", "0", "0", "0", "0", "0", 
                 Integer.toString(sim.cache.getTotalDuration())};
             
             csv.writeNext(initialRecord);
@@ -187,7 +187,8 @@ public class OutputManager {
             // the file already has the correct header line
             // write out each record
             for (CacheItem ci : sim.cache){
-                String[] record = {ci.getFileName(),
+                String[] record = {Integer.toString(ci.getFileId()),
+                    ci.getFileName(),
                     Integer.toString(ci.getLOC()), // max LOC
                     Integer.toString(ci.getLoadCount()),
                     Integer.toString(ci.getHitCount()),

--- a/src/main/java/edu/ucsc/sil/fixcache/cache/OutputManager.java
+++ b/src/main/java/edu/ucsc/sil/fixcache/cache/OutputManager.java
@@ -187,9 +187,9 @@ public class OutputManager {
             
             // the file already has the correct header line
             // write out each record
-            for (CacheItem ci : sim.cache){
+            for (CacheItem ci : sim.cache.allCacheValues()){
                 String[] record = {Integer.toString(ci.getFileId()),
-                    ci.getFileName(),
+                    ci.getFilePath(),
                     Integer.toString(ci.getLOC()), // max LOC
                     Integer.toString(ci.getLoadCount()),
                     Integer.toString(ci.getHitCount()),
@@ -222,13 +222,11 @@ public class OutputManager {
             csv.writeNext(columns);
             
             for (CacheItem ci : sim.cache) {
-                if (ci.isInCache()) {
-                    String[] record = {Integer.toString(ci.getFileId()),
-                                       ci.getFileName()             
-                    };
-                    
-                    csv.writeNext(record);
-                }
+                String[] record = {Integer.toString(ci.getFileId()),
+                                   ci.getFilePath()             
+                };
+                
+                csv.writeNext(record);
             }
             
             csv.close();

--- a/src/main/java/edu/ucsc/sil/fixcache/cache/Simulator.java
+++ b/src/main/java/edu/ucsc/sil/fixcache/cache/Simulator.java
@@ -175,7 +175,7 @@ public class Simulator {
                 final ResultSet files = findFileQuery.executeQuery();
                 // loop through those file ids
                 while (files.next()) {
-                    //System.out.println(cache.toString());
+                    // System.out.println(cache.toString());
                     fileId = files.getInt(1); 
                     type = ActionType.valueOf(files.getString(2));
                     numprefetch = processOneFile(cid, cdate, isBugFix,

--- a/src/main/java/edu/ucsc/sil/fixcache/cache/Simulator.java
+++ b/src/main/java/edu/ucsc/sil/fixcache/cache/Simulator.java
@@ -18,16 +18,11 @@ public class Simulator {
 
     static final String findCommit = "select id, date, is_bug_fix from scmlog "
             + "where repository_id =? and date between ? and ? order by date ASC";
-    static final String findFile = "select fp.file_id, a.type " + 
+    static final String findCommitCodeFiles = "select a.file_id, a.type " + 
     "from actions a, " + 
-    "     file_paths fp, " + 
     "     file_types ft, " + 
     "     content c " + 
-    "where fp.id = (select max(id) " + 
-    "               from file_paths " + 
-    "               where file_id = a.file_id " + 
-    "               and commit_id <= a.commit_id) " + 
-    "and a.commit_id = ? " + 
+    "where a.commit_id = ? " + 
     "and a.file_id = c.file_id " + 
     "and a.commit_id = c.commit_id " + 
     "and a.file_id = ft.file_id " + 
@@ -88,7 +83,7 @@ public class Simulator {
         output = new OutputManager(cache.startDate, in.saveToFile, in.monthly);
 
         try {
-            findFileQuery = conn.prepareStatement(findFile);
+            findFileQuery = conn.prepareStatement(findCommitCodeFiles);
             findCommitQuery = conn.prepareStatement(findCommit);
             findHunkIdQuery = conn.prepareStatement(findHunkId);
             findBugIntroCdateQuery = conn.prepareStatement(findBugIntroCdate);

--- a/src/main/java/edu/ucsc/sil/fixcache/cache/Simulator.java
+++ b/src/main/java/edu/ucsc/sil/fixcache/cache/Simulator.java
@@ -34,7 +34,7 @@ public class Simulator {
     "and ft.type = 'code' " + 
     "order by c.loc desc";
     static final String findHunkId = "select hunks.id from hunks, files "
-            + "where hunks.file_id=? and files.file_id = hunks.file_id and commit_id =?";
+            + "where hunks.file_id=? and files.id = hunks.file_id and commit_id =?";
     static final String findBugIntroCdate = "select date from hunk_blames, scmlog "
             + "where hunk_id =? and hunk_blames.bug_commit_id=scmlog.id";
     private PreparedStatement findCommitQuery;
@@ -262,7 +262,7 @@ public class Simulator {
         // select files that are present at the start time
         // in descending order of LOC 
         
-        final String findInitialPreload = "select files.file_id, content.commit_id "
+        final String findInitialPreload = "select files.id, content.commit_id "
                 + "from content, scmlog, actions, file_types, files "
                 + "where files.repository_id=? and content.commit_id = scmlog.id and date <=? "
                 + "and content.file_id=actions.file_id and files.id=actions.file_id "

--- a/src/test/java/edu/ucsc/sil/fixcache/test/CacheItemTest.java
+++ b/src/test/java/edu/ucsc/sil/fixcache/test/CacheItemTest.java
@@ -39,20 +39,20 @@ public class CacheItemTest {
     public void testCacheItemGet() {
         Cache cache = new Cache(5, new CacheReplacement(
                 CacheReplacement.Policy.AUTHORS), "2009-10-20 01:32:19","2010-01-01 01:01:01", 1);
-        CacheItem ci1 = new CacheItem("e.java", 10, "2009-10-24 14:30:54",
+        CacheItem ci1 = new CacheItem(5, 10, "2009-10-24 14:30:54",
                 CacheReason.BugEntity, cache);
         assertEquals(2, ci1.getNumberOfAuthors());
 
         cache = new Cache(5,
                 new CacheReplacement(CacheReplacement.Policy.BUGS),
                 "2009-10-20 01:32:19", "2010-01-01 01:01:01",1);
-        ci1 = new CacheItem("e.java", 10, "2009-10-24 14:30:54",
+        ci1 = new CacheItem(5, 10, "2009-10-24 14:30:54",
                 CacheReason.BugEntity, cache);
         assertEquals(3, ci1.getNumberOfBugs());
 
         cache = new Cache(5, new CacheReplacement(
                 CacheReplacement.Policy.CHANGES), "2009-10-20 01:32:19", "2010-01-01 01:01:01",1);
-        ci1 = new CacheItem("e.java", 10, "2009-10-24 14:30:54",
+        ci1 = new CacheItem(5, 10, "2009-10-24 14:30:54",
                 CacheReason.BugEntity, cache);
 //        CacheItem ci11 = new CacheItem(1, 1, "2009-10-20 01:32:19.0", CacheReason.BugEntity, cache);
         // assertEquals(3, ci1.getNumberOfChanges());
@@ -64,18 +64,18 @@ public class CacheItemTest {
 
         cache = new Cache(5, new CacheReplacement(
                 CacheReplacement.Policy.AUTHORS), "2009-10-20 01:32:19", "2010-01-01 01:01:01",1);
-        CacheItem ci2 = new CacheItem("a.java", 8, "2009-10-24 07:51:22",
+        CacheItem ci2 = new CacheItem(1, 8, "2009-10-24 07:51:22",
                 CacheReason.BugEntity, cache);
         assertEquals(4, ci2.getNumberOfAuthors());
 
         cache = new Cache(5,new CacheReplacement(CacheReplacement.Policy.BUGS),
                 "2009-10-20 01:32:19","2010-01-01 01:01:01", 1);
-        ci2 = new CacheItem("a.java", 8, "2009-10-24 07:51:22",
+        ci2 = new CacheItem(1, 8, "2009-10-24 07:51:22",
                 CacheReason.BugEntity, cache);
         assertEquals(2, ci2.getNumberOfBugs());
         cache = new Cache(5, new CacheReplacement(
                 CacheReplacement.Policy.CHANGES), "2009-10-20 01:32:19","2010-01-01 01:01:01",1);
-        ci2 = new CacheItem("a.java", 8, "2009-10-24 07:51:22",
+        ci2 = new CacheItem(1, 8, "2009-10-24 07:51:22",
                 CacheReason.BugEntity, cache);
         assertEquals(5, ci2.getNumberOfChanges());
 

--- a/src/test/java/edu/ucsc/sil/fixcache/test/CacheReplacementTest.java
+++ b/src/test/java/edu/ucsc/sil/fixcache/test/CacheReplacementTest.java
@@ -36,23 +36,23 @@ public class CacheReplacementTest {
     public void testCacheReplacementAuthors() {
         Cache cache = new Cache(5, new CacheReplacement(
                 CacheReplacement.Policy.AUTHORS), "2009-10-20 01:32:19", "2010-01-01 01:01:01",1);
-        cache.add("d.java", 1, "2009-10-20 01:32:19", CacheReason.NewEntity);
-        cache.add("c.java", 1, "2009-10-20 01:32:19", CacheReason.NewEntity);
-        cache.add("a.java", 1, "2009-10-20 01:32:19", CacheReason.NewEntity);
-        cache.add("d.java", 2, "2009-10-20 14:37:38", CacheReason.BugEntity);
-        cache.add("a.java", 2, "2009-10-20 14:37:38", CacheReason.BugEntity);
-        cache.add("a.java", 3, "2009-10-20 14:37:47", CacheReason.NewEntity);
-        cache.add("e.java", 3, "2009-10-20 14:37:47", CacheReason.BugEntity);
-        cache.remove("d.java", "2009-10-20 14:37:47");
-        cache.add("a.java", 5, "2009-10-23 14:10:37", CacheReason.BugEntity);
-        cache.add("f.java", 6, "2009-10-23 14:29:05", CacheReason.NewEntity);
-        cache.add("g.java", 6, "2009-10-23 14:29:05", CacheReason.NewEntity);
-        cache.add("c.java", 7, "2009-10-23 20:01:52", CacheReason.BugEntity);
-        cache.add("h.java", 8, "2009-10-24 07:51:22", CacheReason.NewEntity);
-        assertNull(cache.getCacheItem("e.java") );
-        cache.add("a.java", 8, "2009-10-24 07:51:22", CacheReason.ModifiedEntity);
-        cache.add("e.java", 9, "2009-10-24 09:50:26", CacheReason.ModifiedEntity);
-        assertNull(cache.getCacheItem("f.java") );
+        cache.add(4, 1, "2009-10-20 01:32:19", CacheReason.NewEntity);
+        cache.add(3, 1, "2009-10-20 01:32:19", CacheReason.NewEntity);
+        cache.add(1, 1, "2009-10-20 01:32:19", CacheReason.NewEntity);
+        cache.add(4, 2, "2009-10-20 14:37:38", CacheReason.BugEntity);
+        cache.add(1, 2, "2009-10-20 14:37:38", CacheReason.BugEntity);
+        cache.add(1, 3, "2009-10-20 14:37:47", CacheReason.NewEntity);
+        cache.add(5, 3, "2009-10-20 14:37:47", CacheReason.BugEntity);
+        cache.remove(4, "2009-10-20 14:37:47");
+        cache.add(1, 5, "2009-10-23 14:10:37", CacheReason.BugEntity);
+        cache.add(6, 6, "2009-10-23 14:29:05", CacheReason.NewEntity);
+        cache.add(7, 6, "2009-10-23 14:29:05", CacheReason.NewEntity);
+        cache.add(3, 7, "2009-10-23 20:01:52", CacheReason.BugEntity);
+        cache.add(8, 8, "2009-10-24 07:51:22", CacheReason.NewEntity);
+        assertNull(cache.getCacheItem(5) );
+        cache.add(1, 8, "2009-10-24 07:51:22", CacheReason.ModifiedEntity);
+        cache.add(5, 9, "2009-10-24 09:50:26", CacheReason.ModifiedEntity);
+        assertNull(cache.getCacheItem(6) );
     }
 
     @Test
@@ -60,62 +60,62 @@ public class CacheReplacementTest {
         // add stuff to the cache, without bumping out anything
         Cache cache = new Cache(5, new CacheReplacement(
                 CacheReplacement.Policy.LRU), "2009-10-20 01:32:19", "2010-01-01 01:01:01",1);
-        cache.add("a.java", 1, "2009-10-20 01:32:19", CacheReason.NewEntity);
-        cache.add("c.java", 1, "2009-10-20 01:32:19", CacheReason.NewEntity);
-        cache.add("d.java", 1, "2009-10-20 01:32:19", CacheReason.NewEntity);
-        cache.add("a.java", 2, "2009-10-20 14:37:38", CacheReason.BugEntity); // LRU
-        cache.add("d.java", 2, "2009-10-20 14:37:38", CacheReason.BugEntity); // LRU
+        cache.add(1, 1, "2009-10-20 01:32:19", CacheReason.NewEntity);
+        cache.add(3, 1, "2009-10-20 01:32:19", CacheReason.NewEntity);
+        cache.add(4, 1, "2009-10-20 01:32:19", CacheReason.NewEntity);
+        cache.add(1, 2, "2009-10-20 14:37:38", CacheReason.BugEntity); // LRU
+        cache.add(4, 2, "2009-10-20 14:37:38", CacheReason.BugEntity); // LRU
         assertEquals(3, cache.getCacheSize());
-        cache.add("e.java", 3, "2009-10-20 14:37:47", CacheReason.NewEntity); // LRU 3, 5, 2, 4, 1, 3
-        cache.add("a.java", 3, "2009-10-20 14:37:47", CacheReason.BugEntity); // 1,
+        cache.add(5, 3, "2009-10-20 14:37:47", CacheReason.NewEntity); // LRU 3, 5, 2, 4, 1, 3
+        cache.add(1, 3, "2009-10-20 14:37:47", CacheReason.BugEntity); // 1,
         assertEquals(4, cache.getCacheSize());
-        cache.remove("d.java", "2009-10-20 14:37:47"); // 1, 5, 2, 3
+        cache.remove(4, "2009-10-20 14:37:47"); // 1, 5, 2, 3
         assertEquals(3, cache.getCacheSize());
-        cache.add("a.java", 5, "2009-10-23 14:10:37", CacheReason.BugEntity); // 1,
+        cache.add(1, 5, "2009-10-23 14:10:37", CacheReason.BugEntity); // 1,
         assertEquals(3, cache.getCacheSize());
-        cache.add("f.java", 6, "2009-10-23 14:29:05", CacheReason.NewEntity); // 6,
+        cache.add(6, 6, "2009-10-23 14:29:05", CacheReason.NewEntity); // 6,
         assertEquals(4, cache.getCacheSize());
-        assertEquals(1, cache.getLoadCount("c.java"));
+        assertEquals(1, cache.getLoadCount(3));
 
-        assertEquals("c.java", cache.getMinimum());
-        cache.add("g.java", 6, "2009-10-23 14:29:05", CacheReason.NewEntity); // 7,
+        assertEquals(3, cache.getMinimum());
+        cache.add(7, 6, "2009-10-23 14:29:05", CacheReason.NewEntity); // 7,
         assertEquals(5, cache.getCacheSize());
-        cache.add("d.java", 1, "2009-10-20 01:32:19", CacheReason.NewEntity);
+        cache.add(4, 1, "2009-10-20 01:32:19", CacheReason.NewEntity);
         assertEquals(5, cache.getCacheSize());
-        assertNull(cache.getCacheItem("c.java") );
+        assertNull(cache.getCacheItem(3) );
 
-        cache.add("c.java", 7, "2009-10-23 20:01:52", CacheReason.BugEntity); // 3,
-        assertEquals(2, cache.getLoadCount("c.java"));
-        assertNull(cache.getCacheItem("e.java") );
-        cache.add("h.java", 8, "2009-10-24 07:51:22", CacheReason.NewEntity); // 8,
-        assertNull(cache.getCacheItem("a.java") );
-        cache.add("a.java", 8, "2009-10-24 07:51:22", CacheReason.ModifiedEntity); // 1,
-        assertNull(cache.getCacheItem("b") );
-        cache.add("e.java", 9, "2009-10-24 09:50:26", CacheReason.ModifiedEntity);
-        assertNull(cache.getCacheItem("f.java") );
+        cache.add(3, 7, "2009-10-23 20:01:52", CacheReason.BugEntity); // 3,
+        assertEquals(2, cache.getLoadCount(3));
+        assertNull(cache.getCacheItem(5) );
+        cache.add(8, 8, "2009-10-24 07:51:22", CacheReason.NewEntity); // 8,
+        assertNull(cache.getCacheItem(1) );
+        cache.add(1, 8, "2009-10-24 07:51:22", CacheReason.ModifiedEntity); // 1,
+        assertNull(cache.getCacheItem(2) );
+        cache.add(5, 9, "2009-10-24 09:50:26", CacheReason.ModifiedEntity);
+        assertNull(cache.getCacheItem(6) );
     }
 
     @Test
     public void testCacheReplacementChanges() {
         Cache cache = new Cache(5, new CacheReplacement(
                 CacheReplacement.Policy.CHANGES), "2009-10-20 01:32:19.0", "2010-01-01 01:01:01.0",1);
-        cache.add("d.java", 1, "2009-10-20 01:32:19", CacheReason.NewEntity);
-        cache.add("c.java", 1, "2009-10-20 01:32:19", CacheReason.NewEntity);
-        cache.add("a.java", 1, "2009-10-20 01:32:19", CacheReason.NewEntity);
-        cache.add("d.java", 2, "2009-10-20 14:37:38", CacheReason.BugEntity);
-        cache.add("a.java", 2, "2009-10-20 14:37:38", CacheReason.BugEntity);
-        cache.add("a.java", 3, "2009-10-20 14:37:47", CacheReason.NewEntity);
-        cache.add("e.java", 3, "2009-10-20 14:37:47", CacheReason.BugEntity);
-        cache.remove("d.java", "2009-10-20 14:37:47");
-        cache.add("a.java", 5, "2009-10-23 14:10:37", CacheReason.BugEntity);
-        cache.add("f.java", 6, "2009-10-23 14:29:05", CacheReason.NewEntity);
-        cache.add("g.java", 6, "2009-10-23 14:29:05", CacheReason.NewEntity);
-        cache.add("c.java", 7, "2009-10-23 20:01:52", CacheReason.BugEntity);
-        cache.add("h.java", 8, "2009-10-24 07:51:22", CacheReason.NewEntity);
-        assertNull(cache.getCacheItem("e.java") );
-        cache.add("a.java", 8, "2009-10-24 07:51:22", CacheReason.ModifiedEntity);
-        cache.add("e.java", 9, "2009-10-24 09:50:26", CacheReason.ModifiedEntity);
-        assertNull(cache.getCacheItem("f.java") );
+        cache.add(4, 1, "2009-10-20 01:32:19", CacheReason.NewEntity);
+        cache.add(3, 1, "2009-10-20 01:32:19", CacheReason.NewEntity);
+        cache.add(1, 1, "2009-10-20 01:32:19", CacheReason.NewEntity);
+        cache.add(4, 2, "2009-10-20 14:37:38", CacheReason.BugEntity);
+        cache.add(1, 2, "2009-10-20 14:37:38", CacheReason.BugEntity);
+        cache.add(1, 3, "2009-10-20 14:37:47", CacheReason.NewEntity);
+        cache.add(5, 3, "2009-10-20 14:37:47", CacheReason.BugEntity);
+        cache.remove(4, "2009-10-20 14:37:47");
+        cache.add(1, 5, "2009-10-23 14:10:37", CacheReason.BugEntity);
+        cache.add(6, 6, "2009-10-23 14:29:05", CacheReason.NewEntity);
+        cache.add(7, 6, "2009-10-23 14:29:05", CacheReason.NewEntity);
+        cache.add(3, 7, "2009-10-23 20:01:52", CacheReason.BugEntity);
+        cache.add(8, 8, "2009-10-24 07:51:22", CacheReason.NewEntity);
+        assertNull(cache.getCacheItem(5) );
+        cache.add(1, 8, "2009-10-24 07:51:22", CacheReason.ModifiedEntity);
+        cache.add(5, 9, "2009-10-24 09:50:26", CacheReason.ModifiedEntity);
+        assertNull(cache.getCacheItem(6) );
     }
 
     @Test
@@ -123,23 +123,23 @@ public class CacheReplacementTest {
         Cache cache = new Cache(5, new CacheReplacement(
                 CacheReplacement.Policy.BUGS), "2009-10-20 01:32:19.0", "2010-01-01 01:01:01.0",1);
 
-        cache.add("d.java", 1, "2009-10-20 01:32:19", CacheReason.NewEntity);
-        cache.add("c.java", 1, "2009-10-20 01:32:19", CacheReason.NewEntity);
-        cache.add("a.java", 1, "2009-10-20 01:32:19", CacheReason.NewEntity);
-        cache.add("d.java", 2, "2009-10-20 14:37:38", CacheReason.BugEntity);
-        cache.add("a.java", 2, "2009-10-20 14:37:38", CacheReason.BugEntity);
-        cache.add("a.java", 3, "2009-10-20 14:37:47", CacheReason.NewEntity);
-        cache.add("e.java", 3, "2009-10-20 14:37:47", CacheReason.BugEntity);
-        cache.remove("d.java", "2009-10-20 14:37:47");
-        cache.add("a.java", 5, "2009-10-23 14:10:37", CacheReason.BugEntity);
-        cache.add("f.java", 6, "2009-10-23 14:29:05", CacheReason.NewEntity);
-        cache.add("g.java", 6, "2009-10-23 14:29:05", CacheReason.NewEntity);
-        cache.add("c.java", 7, "2009-10-23 20:01:52", CacheReason.BugEntity);
-        cache.add("h.java", 8, "2009-10-24 07:51:22", CacheReason.NewEntity);
-        assertNull(cache.getCacheItem("e.java") );
-        cache.add("a.java", 8, "2009-10-24 07:51:22", CacheReason.ModifiedEntity);
-        cache.add("e.java", 9, "2009-10-24 09:50:26", CacheReason.ModifiedEntity);
-        assertNull(cache.getCacheItem("h.java") );
+        cache.add(4, 1, "2009-10-20 01:32:19", CacheReason.NewEntity);
+        cache.add(3, 1, "2009-10-20 01:32:19", CacheReason.NewEntity);
+        cache.add(1, 1, "2009-10-20 01:32:19", CacheReason.NewEntity);
+        cache.add(4, 2, "2009-10-20 14:37:38", CacheReason.BugEntity);
+        cache.add(1, 2, "2009-10-20 14:37:38", CacheReason.BugEntity);
+        cache.add(1, 3, "2009-10-20 14:37:47", CacheReason.NewEntity);
+        cache.add(5, 3, "2009-10-20 14:37:47", CacheReason.BugEntity);
+        cache.remove(4, "2009-10-20 14:37:47");
+        cache.add(1, 5, "2009-10-23 14:10:37", CacheReason.BugEntity);
+        cache.add(6, 6, "2009-10-23 14:29:05", CacheReason.NewEntity);
+        cache.add(7, 6, "2009-10-23 14:29:05", CacheReason.NewEntity);
+        cache.add(3, 7, "2009-10-23 20:01:52", CacheReason.BugEntity);
+        cache.add(8, 8, "2009-10-24 07:51:22", CacheReason.NewEntity);
+        assertNull(cache.getCacheItem(5) );
+        cache.add(1, 8, "2009-10-24 07:51:22", CacheReason.ModifiedEntity);
+        cache.add(5, 9, "2009-10-24 09:50:26", CacheReason.ModifiedEntity);
+        assertNull(cache.getCacheItem(8) );
     }
 
 }

--- a/src/test/java/edu/ucsc/sil/fixcache/test/CacheTest.java
+++ b/src/test/java/edu/ucsc/sil/fixcache/test/CacheTest.java
@@ -38,23 +38,23 @@ public class CacheTest {
     public void testCacheAdd() {
         Cache cache = new Cache(5, new CacheReplacement(
                 CacheReplacement.Policy.AUTHORS), "2009-10-20 01:32:19.0", "2010-01-01 01:01:01.0",1);
-        cache.add("a.java", 1, "2009-10-20 01:32:19.0", CacheReason.NewEntity);
+        cache.add(1, 1, "2009-10-20 01:32:19.0", CacheReason.NewEntity);
         assertEquals(cache.getCacheSize(), 1);
-        cache.add("g.java", 1, "2009-10-20 01:32:19.0", CacheReason.NewEntity);
+        cache.add(7, 1, "2009-10-20 01:32:19.0", CacheReason.NewEntity);
         assertEquals(cache.getCacheSize(), 2);
-        cache.add("c.java", 1, "2009-10-20 01:32:19.0", CacheReason.NewEntity);
+        cache.add(3, 1, "2009-10-20 01:32:19.0", CacheReason.NewEntity);
         assertEquals(cache.getCacheSize(), 3);
-        cache.add("d.java", 1, "2009-10-20 01:32:19.0", CacheReason.NewEntity);
+        cache.add(4, 1, "2009-10-20 01:32:19.0", CacheReason.NewEntity);
         assertEquals(cache.getCacheSize(), 4);
-        cache.add("a.java", 2, "2009-10-20 14:37:38.0", CacheReason.ModifiedEntity);
+        cache.add(1, 2, "2009-10-20 14:37:38.0", CacheReason.ModifiedEntity);
         assertEquals(cache.getCacheSize(), 4);
-        cache.add("d.java", 2, "2009-10-20 14:37:38.0", CacheReason.ModifiedEntity);
+        cache.add(4, 2, "2009-10-20 14:37:38.0", CacheReason.ModifiedEntity);
         assertEquals(cache.getCacheSize(), 4);
-        cache.add("g.java", 3, "2009-10-20 14:37:47.0", CacheReason.BugEntity);
+        cache.add(7, 3, "2009-10-20 14:37:47.0", CacheReason.BugEntity);
         assertEquals(cache.getCacheSize(), 4);
-        cache.add("e.java", 3, "2009-10-20 14:37:47.0", CacheReason.BugEntity);
+        cache.add(5, 3, "2009-10-20 14:37:47.0", CacheReason.BugEntity);
         assertTrue(cache.isFull());
-        assertEquals(1, cache.getLoadCount("a.java"));
+        assertEquals(1, cache.getLoadCount(1));
     }
 
 }

--- a/src/test/java/edu/ucsc/sil/fixcache/test/CochangeTest.java
+++ b/src/test/java/edu/ucsc/sil/fixcache/test/CochangeTest.java
@@ -38,20 +38,20 @@ public class CochangeTest {
     @Test
     public void testCoChange() {
         Cache cache = new Cache(1, new CacheReplacement(CacheReplacement.Policy.LRU), "","", 1);
-        ArrayList<String> cochanges1 = CoChange.getCoChangeFileList("e.java", "2009-10-20 01:32:19",
+        ArrayList<Integer> cochanges1 = CoChange.getCoChangeFileList(5, "2009-10-20 01:32:19",
                 "2009-10-24 09:50:26.0", 3, 1, cache);
         assertEquals(cochanges1.size(), 1);
-        assertTrue(cochanges1.contains("a.java"));
-        ArrayList<String> cochanges2 = CoChange.getCoChangeFileList("a.java","2009-10-20 01:32:19",
+        assertTrue(cochanges1.contains(1));
+        ArrayList<Integer> cochanges2 = CoChange.getCoChangeFileList(1,"2009-10-20 01:32:19",
                 "2009-10-24 07:51:22.0", 4, 1, cache);
         assertEquals(cochanges2.size(), 3);
-        assertTrue(cochanges2.contains("d.java"));
-        assertTrue(cochanges2.contains("h.java"));
-        assertTrue(cochanges2.contains("e.java"));
-        ArrayList<String> cochanges3 = CoChange.getCoChangeFileList("g.java","2009-10-20 01:32:19",
+        assertTrue(cochanges2.contains(4));
+        assertTrue(cochanges2.contains(8));
+        assertTrue(cochanges2.contains(5));
+        ArrayList<Integer> cochanges3 = CoChange.getCoChangeFileList(7,"2009-10-20 01:32:19",
                 "2009-10-23 14:29:05.0", 5, 1, cache);
         assertEquals(cochanges3.size(), 1);
-        assertTrue(cochanges3.contains("f.java"));
+        assertTrue(cochanges3.contains(6));
     }
 
 }

--- a/src/test/java/edu/ucsc/sil/fixcache/test/SimulatorTest.java
+++ b/src/test/java/edu/ucsc/sil/fixcache/test/SimulatorTest.java
@@ -47,16 +47,16 @@ public class SimulatorTest {
         Simulator sim1 = new Simulator(in);
         sim1.initialPreLoad();
         assertEquals(3, sim1.getCache().getCacheSize()); // only 3 files in inital commit
-        assertTrue(sim1.getCache().contains("d.java"));
-        assertTrue(sim1.getCache().contains("c.java"));
+        assertTrue(sim1.getCache().contains(4));
+        assertTrue(sim1.getCache().contains(3));
         sim1.closeStatement();
 
         in.setStartDate("2009-10-20 14:37:47");
         Simulator sim2 = new Simulator(in);
         sim2.initialPreLoad();
         assertEquals(4, sim2.getCache().getCacheSize());
-        assertTrue(sim2.getCache().contains("a.java"));
-        assertTrue(sim2.getCache().contains("e.java"));
+        assertTrue(sim2.getCache().contains(1));
+        assertTrue(sim2.getCache().contains(5));
         sim2.closeStatement();
 
 
@@ -64,7 +64,7 @@ public class SimulatorTest {
         Simulator sim3 = new Simulator(in);
         sim3.initialPreLoad();
         assertEquals(4, sim3.getCache().getCacheSize());
-        assertTrue(sim3.getCache().contains("a.java"));
+        assertTrue(sim3.getCache().contains(1));
         sim3.closeStatement();
 
 
@@ -79,9 +79,9 @@ public class SimulatorTest {
         Cache cache = sim.getCache();
         sim.initialPreLoad();
         assertEquals(cache.getCacheSize(), 3);
-        sim.add("a.java", 1, "2009-10-20 01:32:19", CacheItem.CacheReason.NewEntity);
+        sim.add(1, 1, "2009-10-20 01:32:19", CacheItem.CacheReason.NewEntity);
         assertEquals(cache.getCacheSize(), 3);
-        sim.add("c.java", 1, "2009-10-20 01:32:19", CacheItem.CacheReason.NewEntity);
+        sim.add(3, 1, "2009-10-20 01:32:19", CacheItem.CacheReason.NewEntity);
         assertEquals(cache.getCacheSize(), 3);
         sim.closeStatement();
     }
@@ -104,11 +104,11 @@ public class SimulatorTest {
         in.setStartDate("2009-10-20 01:32:19");
         Simulator sim = new Simulator(in);
         Cache cache = sim.getCache();
-        sim.loadBuggyEntity("e.java", 9, "2009-10-24 09:50:26",
+        sim.loadBuggyEntity(5, 9, "2009-10-24 09:50:26",
                 "2009-10-23 20:01:52");
-        assertNotNull(cache.getCacheItem("e.java"));
-        assertNull(cache.getCacheItem("b"));
-        assertNotNull(cache.getCacheItem("a.java"));
+        assertNotNull(cache.getCacheItem(5));
+        assertNull(cache.getCacheItem(2));
+        assertNotNull(cache.getCacheItem(1));
         assertEquals(sim.getHit(), 0);
         assertEquals(sim.getMiss(), 1);
         sim.closeStatement();

--- a/test.sql
+++ b/test.sql
@@ -65,6 +65,14 @@ CREATE TABLE `file_links` (
   `commit_id` int(11) DEFAULT NULL
 );
 
+DROP TABLE IF EXISTS `file_paths`;
+CREATE TABLE  `file_paths` (
+  `id` int(11) NOT NULL,
+  `commit_id` int(11) DEFAULT NULL,
+  `file_id` int(11) DEFAULT NULL,
+  `file_path` varchar(255) DEFAULT NULL
+);
+
 DROP TABLE IF EXISTS `file_types`;
 CREATE TABLE `file_types` (
   `id` int(11) NOT NULL,


### PR DESCRIPTION
Hello all,
This is an update to FixCache which changes it to use file paths, not file names. I found the bug that was eating memory, and file paths now works as quick (if not quicker) than the current FixCache release. 

All tests are passing, but I'm sending for review as the FixCache codebase isn't my baby, and such a change should ideally be at least glanced at.
